### PR TITLE
Catch sample failure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: swissknife
 Title: Handy code shared in the FMI CompBio group
-Version: 0.4
+Version: 0.5
 Authors@R: c(person("Michael", "Stadler", email = "michael.stadler@fmi.ch", role = c("aut", "cre")),
              person("Charlotte", "Soneson", email = "charlotte.soneson@fmi.ch", role = "aut"),
              person("Panagiotis", "Papasaikas", email = "panagiotis.papasaikas@fmi.ch", role = "aut"),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+CHANGES IN VERSION 0.5
+----------------------
+
+  o sampleControlElements() now catches cases with too few control elements to match the target distribution
+
 CHANGES IN VERSION 0.4
 ----------------------
 

--- a/man/sampleControlElements.Rd
+++ b/man/sampleControlElements.Rd
@@ -21,7 +21,7 @@ from which a subset is to be sampled.}
 \item{nbins}{`numeric(1)` or `numeric(length(x))` if `x` is a list, specifying the
 number of bins to group the values of x into. Higher numbers of bins will
 increase the match to the target distribution(s), but may fail if there are
-few elements to sample from.}
+few elements to sample from (will throw a warning).}
 
 \item{oversample}{The number of control elements to sample for each target element.}
 }

--- a/tests/testthat/test_sampleControlElements.R
+++ b/tests/testthat/test_sampleControlElements.R
@@ -13,6 +13,10 @@ test_that("sampleControlElements() works properly", {
     expect_true(is.numeric(s3 <- sampleControlElements(list(x),
                                       idxTarget = rep(c(FALSE,TRUE),c(length(i.control),length(i.target))),
                                       idxControl = i.control)))
+    expect_error(sampleControlElements(x, i.target, i.control, oversample = 100))
+    expect_warning(s4 <- sampleControlElements(list(x, runif(length(x))),
+                                               i.target, i.control, nbins = c(100,100)),
+                   regexp = "Too few control elements")
 
     expect_equal(length(s1), length(i.target))
     expect_equal(s1, s2)


### PR DESCRIPTION
Hi Dania

This should now catch cases where there are not enough control elements at all (throws an error), or that match the target distribution well (throws a warning and will sample from what it has).

Thanks a lot for checking!
Michael