### PR TITLE
truncate chr names after first whitespace like bowtie

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: swissknife
 Title: Handy code shared in the FMI CompBio group
-Version: 0.27
+Version: 0.28
 Authors@R: c(person("Michael", "Stadler", email = "michael.stadler@fmi.ch", role = c("aut", "cre")),
              person("Charlotte", "Soneson", email = "charlotte.soneson@fmi.ch", role = "aut"),
              person("Panagiotis", "Papasaikas", email = "panagiotis.papasaikas@fmi.ch", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# swissknife 0.28
+
+* Truncate chromosome names after first whitespace in getGenomicTiles when checking consistency
+
 # swissknife 0.27
 
 * Add getGenomicTiles to obtain annotated regions tiling a given genome

--- a/R/getMappableRegions.R
+++ b/R/getMappableRegions.R
@@ -76,6 +76,7 @@ getMappableRegions <- function(genome,
                                      start = 1, end = seqlengths(chrinfo))
         } else if (file.exists(genome)) {
             chrs <- Biostrings::readDNAStringSet(genome)
+            names(chrs) <- sub(" .+$", "", names(chrs))
         } else {
             stop("'genome' is neither a valid file nor a BSgenome object.")
         }


### PR DESCRIPTION
bowtie does this, too, so in order to check consistency of chromosome names and lengths between genome fasta file and bowtie index, this behavior has to be replicated.